### PR TITLE
fix(dependencies): adds babel-runtime as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,16 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "chalk": "^1.1.3",
     "cli-table2": "^0.2.0",
     "commander": "^2.9.0",
+    "fs-promise": "^1.0.0",
     "inquirer": "^1.2.3",
     "jira-client": "^4.2.0",
     "moment": "^2.17.1",
-    "fs-promise": "^1.0.0",
-    "rimraf": "^2.5.4",
-    "opn": "^4.0.2"
+    "opn": "^4.0.2",
+    "rimraf": "^2.5.4"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/issues.js
+++ b/src/issues.js
@@ -42,7 +42,7 @@ export default class JiraIssues {
 	* Crate a new issue object
 	* Docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-createIssue
 	*/
-	createIssueObj( options ) {
+	createIssueObj( options = {} ) {
 
 		const _this = this;
 		
@@ -124,7 +124,7 @@ export default class JiraIssues {
 					};
 			    
 			    	// Assign the issue to the current user if self option is passed
-			    	if(  typeof options.self !== 'undefined' ) {
+			    	if( typeof options.self !== 'undefined' ) {
 			    		newIssue.fields.assignee = { name: jira.config.defaults.username };
 			    	}
 
@@ -146,6 +146,9 @@ export default class JiraIssues {
 			    	} else {
 			    		_this.createIssue( newIssue );
 			    	}
+				}).catch((err) => { 
+					console.log(err); 
+					process.exit();
 				});
 			});
 		});


### PR DESCRIPTION
Missing `babel-runtime` dependency.

<img width="565" alt="screen shot 2017-03-27 at 5 57 50 pm" src="https://cloud.githubusercontent.com/assets/573625/24379945/48dddc3a-1317-11e7-8b7b-dd9a61fc6735.png">
