### PR TITLE
make config file created same as the documentation

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -26,7 +26,7 @@ class JiraCLI {
   constructor(){
 
     // Set the config file name
-    this.configFileName = '.jira-cl.json';
+    this.configFileName = '.jira-cli.json';
 
     // Create instance of each module
     this.config = new Config;


### PR DESCRIPTION
Either we make the documentation [here](https://docs.jiracli.com/#general_versions) refer to a "~ /.jira-cl.json" config file being created or we make the code create a "~/.jira-cli.json" file to match the docs.

Engineers rely on the docs as an accurate source of truth about what the code is doing.

Feel free to close this if the docs and repo readme are updated.